### PR TITLE
feat: support expanding variables in env blocks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,4 +53,4 @@ jobs:
       - name: Test examples
         run: |
           ./bin/mdtest version
-          ./bin/mdtest examples/
+          ./bin/mdtest --warnings-as-errors examples/

--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ To build the application and execute the tests in [examples/](./examples/) direc
 
 ```sh
 make
-./bin/mdtest examples/
+./bin/mdtest --warnings-as-errors examples/
 ```

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -37,7 +37,7 @@ func testdataExpectedJUnitXML() string {
   </testcase>
   <testcase classname="Test JUnit XML output" name="Fail: test environment variable values" time="ELAPSED">
     <failure>expected exit code 0, got 1</failure>
-    <system-out># Step 1:&#xA;+ berry=banana&#xA;berry=banana&#xA;+ fruit=apple&#xA;fruit=apple&#xA;+ berry_fruit=&#34;${berry}-${fruit}&#34;&#xA;berry_fruit=banana-apple&#xA;# Step 2:&#xA;+ test banana = strawberry&#xA;</system-out>
+    <system-out># Step 1:&#xA;# berry=banana&#xA;+ berry=banana&#xA;# fruit=apple&#xA;+ fruit=apple&#xA;# berry_fruit=&#34;${berry}-${fruit}&#34;&#xA;+ berry_fruit=banana-apple&#xA;# Step 2:&#xA;+ test banana = strawberry&#xA;</system-out>
   </testcase>
   <testcase classname="Test JUnit XML output" name="Fail: failing step, skipped step, and (failing) cleanup step" time="ELAPSED">
     <failure>expected exit code 0, got 4</failure>
@@ -52,7 +52,7 @@ func testdataExpectedJUnitXML() string {
     <system-out># Step 1:&#xA;# No output&#xA;</system-out>
   </testcase>
   <testcase classname="Test JUnit XML output" name="Success: skip sh step with when expression" time="ELAPSED">
-    <system-out># Step 1:&#xA;+ exit 0&#xA;# Step 2:&#xA;# Skipped&#xA;# Step 3:&#xA;+ VAR=VALUE&#xA;VAR=VALUE&#xA;# Step 4:&#xA;%s&#xA;Environment variable VAR is set to VALUE&#xA;# Step 5:&#xA;# Skipped&#xA;</system-out>
+    <system-out># Step 1:&#xA;+ exit 0&#xA;# Step 2:&#xA;# Skipped&#xA;# Step 3:&#xA;# VAR=VALUE&#xA;+ VAR=VALUE&#xA;# Step 4:&#xA;%s&#xA;Environment variable VAR is set to VALUE&#xA;# Step 5:&#xA;# Skipped&#xA;</system-out>
   </testcase>
   <testcase classname="Test JUnit XML output" name="Sleep" time="ELAPSED">
     <failure>test run timeout exceeded</failure>%s
@@ -60,11 +60,11 @@ func testdataExpectedJUnitXML() string {
   </testcase>
   <testcase classname="Test JUnit XML output" name="Warn: variable key should not contain whitespace" time="ELAPSED">
     <failure>test run timeout exceeded</failure>
-    <system-out># Step 1:&#xA;+ VAR with whitespace=value&#xA;VAR with whitespace=value&#xA;# Warning: variable key should not contain whitespace: VAR with whitespace=value&#xA;</system-out>
+    <system-out># Step 1:&#xA;# VAR with whitespace=value&#xA;+ VAR with whitespace=value&#xA;# Warning: variable key should not contain whitespace: VAR with whitespace=value&#xA;</system-out>
   </testcase>
   <testcase classname="Test JUnit XML output" name="Warn: variable values that contain whitespace should be quoted" time="ELAPSED">
     <failure>test run timeout exceeded</failure>
-    <system-out># Step 1:&#xA;+ VAR=Value with whitespace&#xA;VAR=Value with whitespace&#xA;# Warning: variable values that contain whitespace should be quoted: VAR=Value with whitespace&#xA;</system-out>
+    <system-out># Step 1:&#xA;# VAR=Value with whitespace&#xA;+ VAR=Value with whitespace&#xA;# Warning: variable values that contain whitespace should be quoted: VAR=Value with whitespace&#xA;</system-out>
   </testcase>
 </testsuite>`, xEchoCommandWithQuotes, timeoutExitCodeFailure)
 }
@@ -149,7 +149,7 @@ func TestRoot_testdata(t *testing.T) {
 			junitXML: `<testsuite name="Test JUnit XML output" tests="1" failures="1" errors="0" skipped="0" time="ELAPSED" timestamp="STARTED">
   <testcase classname="Test JUnit XML output" name="Warn: variable key should not contain whitespace" time="ELAPSED">
     <failure>variable key should not contain whitespace: VAR with whitespace=value</failure>
-    <system-out># Step 1:&#xA;+ VAR with whitespace=value&#xA;VAR with whitespace=value&#xA;</system-out>
+    <system-out># Step 1:&#xA;# VAR with whitespace=value&#xA;+ VAR with whitespace=value&#xA;</system-out>
   </testcase>
 </testsuite>`,
 		},

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -72,7 +72,7 @@ func testdataExpectedJUnitXML() string {
 func readJUnitXML(t *testing.T, path string) string {
 	t.Helper()
 
-	reportBytes, err := os.ReadFile(path) //nolint:gosec // This is a test helper function, so reading files is expected and not a security risk
+	reportBytes, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("Failed to read JUnit XML file: %v", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,8 +16,9 @@ var (
 	name             string
 	numberOfJobs     int
 	timeout          time.Duration
-	junitXML         string
 	outputToTerminal bool
+	warningsAsErrors bool
+	junitXML         string
 
 	rootCmd = &cobra.Command{
 		Use:   "mdtest [flags] path ...",
@@ -34,6 +35,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&junitXML, "junit-xml", "x", "", "generate JUnit XML report to the specified `path`")
 	rootCmd.Flags().DurationVar(&timeout, "timeout", 0, "timeout for the test run as a `duration` string, e.g., 1s, 1m, 1h")
 	rootCmd.Flags().BoolVar(&outputToTerminal, "output-to-terminal", false, "print output from `sh` blocks to the terminal in real-time. Only available when running tests non-concurrently: use either `--jobs=1` or target a single test file when using this flag.")
+	rootCmd.Flags().BoolVar(&warningsAsErrors, "warnings-as-errors", false, "treat warnings as errors, i.e., fail the test run if any warnings are encountered")
 
 	rootCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		if outputToTerminal && numberOfJobs > 1 {
@@ -59,6 +61,7 @@ func init() {
 			Timeout:          timeout,
 			JUnitXML:         junitXML,
 			OutputToTerminal: outputToTerminal,
+			WarningsAsErrors: warningsAsErrors,
 		}
 
 		res := testrun.Execute(args, params)

--- a/examples/04_setting_env_variables.md
+++ b/examples/04_setting_env_variables.md
@@ -10,9 +10,9 @@ test -z "$example_var"
 The above test will fail because $example_var is not set (or it is empty). Let's defined it in a env block.
 
 ```env
-example_var=Example value
+example_var="Example value"
 
-another_var=Another value
+another_var="Another value"
 ```
 
 The variable is now defined in following test steps.
@@ -23,4 +23,47 @@ test -n "$example_var"
 test -n "$another_var"
 ```
 
+The variable definitions can reference other variables by using `$key` or `${key}` syntax. For example:
+
+```env
+FRUIT=apple
+COLOR=red
+UNQUOTED=${COLOR}-${FRUIT}
+SINGLE_QUOTED='${COLOR}-${FRUIT}'
+DOUBLE_QUOTED="${COLOR}-${FRUIT}"
+```
+
+We can use `test` command to verify that the variables are expanded as expected:
+
+```sh
+test "$UNQUOTED" = "red-apple"
+test "$SINGLE_QUOTED" = '${COLOR}-${FRUIT}'
+test "$DOUBLE_QUOTED" = "red-apple"
+```
+
+Use `#` character at the beginning of a line to add comments to `env` code block.
+
+```env
+# This is a comment
+#commented=value
+
+COLOR=#7b00ff
+```
+
+The first two lines in the above code block are ignored, so `commented` variable is not defined in following test steps.
+
+```sh
+test -z "$commented"
+test "$COLOR" = "#7b00ff"
+```
+
+## Variable precedence
+
 The environment variables defined in `env` code-block can be overridden by defining environment variable with the same name in the `mdtest` command using `-e`/`--env` parameter, for example `--env TARGET=TEST`.
+
+Full precedence order of environment variables is as follows (from lowest to highest):
+
+1. Environment variables from the parent process
+2. Environment variables defined in `env` code blocks
+3. Environment variables defined in `mdtest` command using `-e`/`--env` parameter
+4. Built-in environment variables (e.g. `MDTEST_VERSION` and `MDTEST_WORKSPACE`)

--- a/examples/04_setting_env_variables.md
+++ b/examples/04_setting_env_variables.md
@@ -41,24 +41,24 @@ test "$SINGLE_QUOTED" = '${COLOR}-${FRUIT}'
 test "$DOUBLE_QUOTED" = "red-apple"
 ```
 
-Use `#` character at the beginning of a line to add comments to `env` code block.
+Use `#` character at the beginning of a line (or preceded by whitespace) to add comments to `env` code block.
 
 ```env
 # This is a comment
 #commented=value
 
 COLOR=#7b00ff
-MESSAGE=Enjoying life #blessed
-QUOTED_MESSAGE="Enjoying life #blessed"
+WITH_COMMENT=value #comment
+WITH_HASHTAG="Enjoying life #blessed"
 ```
 
-The first two lines in the above code block are ignored, so `commented` variable is not defined in following test steps. A `#` character preceded by whitespace starts a comment when it is not quoted.
+The first two lines in the above code block are ignored, so `commented` variable is not defined in following test steps.
 
 ```sh
 test -z "$commented"
 test "$COLOR" = "#7b00ff"
-test "$MESSAGE" = "Enjoying life"
-test "$QUOTED_MESSAGE" = "Enjoying life #blessed"
+test "$WITH_COMMENT" = "value"
+test "$WITH_HASHTAG" = "Enjoying life #blessed"
 ```
 
 ## Variable precedence

--- a/examples/04_setting_env_variables.md
+++ b/examples/04_setting_env_variables.md
@@ -48,13 +48,17 @@ Use `#` character at the beginning of a line to add comments to `env` code block
 #commented=value
 
 COLOR=#7b00ff
+MESSAGE=Enjoying life #blessed
+QUOTED_MESSAGE="Enjoying life #blessed"
 ```
 
-The first two lines in the above code block are ignored, so `commented` variable is not defined in following test steps.
+The first two lines in the above code block are ignored, so `commented` variable is not defined in following test steps. A `#` character preceded by whitespace starts a comment when it is not quoted.
 
 ```sh
 test -z "$commented"
 test "$COLOR" = "#7b00ff"
+test "$MESSAGE" = "Enjoying life"
+test "$QUOTED_MESSAGE" = "Enjoying life #blessed"
 ```
 
 ## Variable precedence

--- a/testcase/envstep.go
+++ b/testcase/envstep.go
@@ -2,6 +2,11 @@ package testcase
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"regexp"
 	"strings"
 
 	"github.com/UpCloudLtd/mdtest/utils"
@@ -13,12 +18,86 @@ type envStep struct {
 
 var _ Step = envStep{}
 
+var (
+	whitespaceRe  = regexp.MustCompile(`\s`)
+	singlequoteRe = regexp.MustCompile(`^'[^']*'$`)
+	doublequoteRe = regexp.MustCompile(`^".*"$`)
+)
+
+func parseValue(value string, env EnvBySource, envUpdates []string) (string, error) {
+	var err error
+
+	// Do not expand variables in single quotes, but remove the quotes
+	if singlequoteRe.MatchString(value) {
+		return value[1 : len(value)-1], nil
+	}
+
+	// Remove double quotes
+	if doublequoteRe.MatchString(value) {
+		value = value[1 : len(value)-1]
+	} else if whitespaceRe.MatchString(value) {
+		// Return an error (with the parsed value) if unquoted value contains whitespace, as it would fail when executed in shell. The error is shown as a warning in the test output.
+		err = errors.New("variable values that contain whitespace should be quoted")
+	}
+
+	// Expand variables in unquoted and double-quoted values
+	return os.Expand(value, func(key string) string {
+		env = maps.Clone(env)
+		env[EnvSourceTestcase] = append(env[EnvSourceTestcase], envUpdates...)
+
+		m := utils.EnvEntriesAsMap(env.Merge())
+		return m[key]
+	}), err
+}
+
 func (s envStep) Execute(_ context.Context, t *testStatus) StepResult {
-	t.Env[EnvSourceTestcase] = append(t.Env[EnvSourceTestcase], s.envUpdates...)
+	var envUpdates []string
+	var output strings.Builder
+	var warnings []string
+
+	for _, line := range s.envUpdates {
+		trimmed := strings.TrimSpace(line)
+
+		// Skip empty lines without adding them to output
+		if trimmed == "" {
+			continue
+		}
+
+		// Skip comments after adding them to output
+		if strings.HasPrefix(trimmed, "#") {
+			output.WriteString(fmt.Sprintf("%s\n", trimmed))
+			continue
+		}
+
+		output.WriteString(fmt.Sprintf("+ %s\n", trimmed))
+
+		parts := strings.SplitN(trimmed, "=", 2)
+		if whitespaceRe.MatchString(parts[0]) {
+			warnings = append(warnings, fmt.Sprintf(`variable key should not contain whitespace: %s`, trimmed))
+		}
+
+		if len(parts) < 2 {
+			envUpdates = append(envUpdates, trimmed)
+			output.WriteString(fmt.Sprintf("%s=", parts[0]))
+			continue
+		}
+
+		value, err := parseValue(parts[1], t.Env, envUpdates)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf(`%s: %s`, err.Error(), trimmed))
+		}
+		envUpdate := fmt.Sprintf("%s=%s", parts[0], value)
+
+		envUpdates = append(envUpdates, envUpdate)
+		output.WriteString(fmt.Sprintln(envUpdate))
+	}
+
+	t.Env[EnvSourceTestcase] = append(t.Env[EnvSourceTestcase], envUpdates...)
 
 	return StepResult{
-		Status: StepStatusSuccess,
-		Output: strings.Join(s.envUpdates, "\n"),
+		Status:   StepStatusSuccess,
+		Output:   output.String(),
+		Warnings: warnings,
 	}
 }
 

--- a/testcase/envstep.go
+++ b/testcase/envstep.go
@@ -87,7 +87,7 @@ func (s envStep) Execute(_ context.Context, t *testStatus) StepResult {
 			continue
 		}
 
-		fmt.Fprintf(writer, "+ %s\n", trimmed)
+		fmt.Fprintf(writer, "# %s\n", trimmed)
 
 		parts := strings.SplitN(trimmed, "=", 2)
 		if whitespaceRe.MatchString(parts[0]) {
@@ -96,7 +96,7 @@ func (s envStep) Execute(_ context.Context, t *testStatus) StepResult {
 
 		if len(parts) < 2 {
 			envUpdates = append(envUpdates, trimmed)
-			fmt.Fprintf(writer, "%s=", parts[0])
+			fmt.Fprintf(writer, "+ %s=", parts[0])
 			continue
 		}
 
@@ -109,7 +109,7 @@ func (s envStep) Execute(_ context.Context, t *testStatus) StepResult {
 		envUpdate := fmt.Sprintf("%s=%s", parts[0], value)
 
 		envUpdates = append(envUpdates, envUpdate)
-		fmt.Fprintf(writer, "%s\n", envUpdate)
+		fmt.Fprintf(writer, "+ %s\n", envUpdate)
 	}
 
 	t.Env[EnvSourceTestcase] = append(t.Env[EnvSourceTestcase], envUpdates...)

--- a/testcase/envstep.go
+++ b/testcase/envstep.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"regexp"
@@ -55,6 +56,11 @@ func (s envStep) Execute(_ context.Context, t *testStatus) StepResult {
 	var output strings.Builder
 	var warnings []string
 
+	var writer io.Writer = &output
+	if t.Params.OutputToTerminal {
+		writer = io.MultiWriter(&output, safeWriter(t.Params.StderrWriter))
+	}
+
 	for _, line := range s.envUpdates {
 		trimmed := strings.TrimSpace(line)
 
@@ -65,11 +71,11 @@ func (s envStep) Execute(_ context.Context, t *testStatus) StepResult {
 
 		// Skip comments after adding them to output
 		if strings.HasPrefix(trimmed, "#") {
-			output.WriteString(fmt.Sprintf("%s\n", trimmed))
+			fmt.Fprintf(writer, "%s\n", trimmed)
 			continue
 		}
 
-		output.WriteString(fmt.Sprintf("+ %s\n", trimmed))
+		fmt.Fprintf(writer, "+ %s\n", trimmed)
 
 		parts := strings.SplitN(trimmed, "=", 2)
 		if whitespaceRe.MatchString(parts[0]) {
@@ -78,7 +84,7 @@ func (s envStep) Execute(_ context.Context, t *testStatus) StepResult {
 
 		if len(parts) < 2 {
 			envUpdates = append(envUpdates, trimmed)
-			output.WriteString(fmt.Sprintf("%s=", parts[0]))
+			fmt.Fprintf(writer, "%s=", parts[0])
 			continue
 		}
 
@@ -89,7 +95,7 @@ func (s envStep) Execute(_ context.Context, t *testStatus) StepResult {
 		envUpdate := fmt.Sprintf("%s=%s", parts[0], value)
 
 		envUpdates = append(envUpdates, envUpdate)
-		output.WriteString(fmt.Sprintln(envUpdate))
+		fmt.Fprintf(writer, "%s\n", envUpdate)
 	}
 
 	t.Env[EnvSourceTestcase] = append(t.Env[EnvSourceTestcase], envUpdates...)

--- a/testcase/envstep.go
+++ b/testcase/envstep.go
@@ -21,24 +21,36 @@ var _ Step = envStep{}
 
 var (
 	whitespaceRe  = regexp.MustCompile(`\s`)
-	singlequoteRe = regexp.MustCompile(`^'[^']*'$`)
+	singlequoteRe = regexp.MustCompile(`^'.*'$`)
 	doublequoteRe = regexp.MustCompile(`^".*"$`)
+	innerQuotesRe = regexp.MustCompile(`(^"(.*".*)+"$)|(^'(.*'.*)'$)|(^[^'"](.*['"].*)+[^'"]$)`)
+	commentRe     = regexp.MustCompile(`\s+#.*`)
 )
 
-func parseValue(value string, env EnvBySource, envUpdates []string) (string, error) {
-	var err error
+func parseValue(value string, env EnvBySource, envUpdates []string) (string, []error) {
+	var errs []error
+
+	// Check if value contains inner quotes as these are maintained by default (unlike in shell).
+	if innerQuotesRe.MatchString(value) {
+		errs = append(errs, errors.New("variable values with inner quotes should be quoted"))
+	}
 
 	// Do not expand variables in single quotes, but remove the quotes
 	if singlequoteRe.MatchString(value) {
-		return value[1 : len(value)-1], nil
+		return value[1 : len(value)-1], errs
 	}
 
 	// Remove double quotes
 	if doublequoteRe.MatchString(value) {
 		value = value[1 : len(value)-1]
-	} else if whitespaceRe.MatchString(value) {
-		// Return an error (with the parsed value) if unquoted value contains whitespace, as it would fail when executed in shell. The error is shown as a warning in the test output.
-		err = errors.New("variable values that contain whitespace should be quoted")
+	} else {
+		// Remove comments from unquoted values
+		value = commentRe.ReplaceAllString(value, "")
+
+		if whitespaceRe.MatchString(value) {
+			// Return an error (with the parsed value) if unquoted value contains whitespace, as it would fail when executed in shell. The error is shown as a warning in the test output.
+			errs = append(errs, errors.New("variable values that contain whitespace should be quoted"))
+		}
 	}
 
 	// Expand variables in unquoted and double-quoted values
@@ -48,7 +60,7 @@ func parseValue(value string, env EnvBySource, envUpdates []string) (string, err
 
 		m := utils.EnvEntriesAsMap(env.Merge())
 		return m[key]
-	}), err
+	}), errs
 }
 
 func (s envStep) Execute(_ context.Context, t *testStatus) StepResult {
@@ -88,9 +100,11 @@ func (s envStep) Execute(_ context.Context, t *testStatus) StepResult {
 			continue
 		}
 
-		value, err := parseValue(parts[1], t.Env, envUpdates)
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf(`%s: %s`, err.Error(), trimmed))
+		value, errs := parseValue(parts[1], t.Env, envUpdates)
+		if len(errs) > 0 {
+			for _, err := range errs {
+				warnings = append(warnings, fmt.Sprintf(`%s: %s`, err.Error(), trimmed))
+			}
 		}
 		envUpdate := fmt.Sprintf("%s=%s", parts[0], value)
 

--- a/testcase/envstep_internal_test.go
+++ b/testcase/envstep_internal_test.go
@@ -1,0 +1,82 @@
+package testcase
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvStep_parseValue(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name   string
+		value  string
+		output string
+		errors []string
+	}{
+		{
+			name:   "Inner single quotes in unquoted value",
+			value:  `asd'123'asd`,
+			output: `asd'123'asd`,
+			errors: []string{"variable values with inner quotes should be quoted"},
+		},
+		{
+			name:   "Inner single quotes in single quoted value",
+			value:  `'asd'123'asd'`,
+			output: `asd'123'asd`,
+			errors: []string{"variable values with inner quotes should be quoted"},
+		},
+		{
+			name:   "Inner double quotes in unquoted value",
+			value:  `{"key": "value"}`,
+			output: `{"key": "value"}`,
+			errors: []string{
+				"variable values with inner quotes should be quoted",
+				"variable values that contain whitespace should be quoted",
+			},
+		},
+		{
+			name:   "Inner double quotes in double quoted value",
+			value:  `"{"key": "value"}"`,
+			output: `{"key": "value"}`,
+			errors: []string{"variable values with inner quotes should be quoted"},
+		},
+		{
+			name:   "Inner double quotes in single quoted value",
+			value:  `'{"key": "value"}'`,
+			output: `{"key": "value"}`,
+		},
+		{
+			name:   "Hashtag in unquoted value",
+			value:  `Enjoying life #blessed`,
+			output: `Enjoying life`,
+			errors: []string{"variable values that contain whitespace should be quoted"},
+		},
+		{
+			name:   "Hashtag in single quoted value",
+			value:  `'Enjoying life #blessed'`,
+			output: `Enjoying life #blessed`,
+		},
+		{
+			name:   "Hashtag in double quoted value",
+			value:  `"Enjoying life #blessed"`,
+			output: `Enjoying life #blessed`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			output, errs := parseValue(test.value, nil, nil)
+			assert.Equal(t, test.output, output)
+			require.Len(t, errs, len(test.errors))
+
+			if len(test.errors) > 0 {
+				for i, err := range errs {
+					assert.Equal(t, test.errors[i], err.Error())
+				}
+			}
+		})
+	}
+}

--- a/testcase/safewriter.go
+++ b/testcase/safewriter.go
@@ -1,0 +1,11 @@
+package testcase
+
+import "io"
+
+// safeWriter returns a non-nil io.Writer. If the provided writer is nil, it returns io.Discard.
+func safeWriter(w io.Writer) io.Writer {
+	if w == nil {
+		return io.Discard
+	}
+	return w
+}

--- a/testcase/shstep.go
+++ b/testcase/shstep.go
@@ -28,13 +28,6 @@ func (s shStep) shParams() string {
 	return "-xec"
 }
 
-func safeWriter(w io.Writer) io.Writer {
-	if w == nil {
-		return io.Discard
-	}
-	return w
-}
-
 func unexpectedExitCode(expected, got int) error {
 	return fmt.Errorf("expected exit code %d, got %d", expected, got)
 }

--- a/testcase/testcase.go
+++ b/testcase/testcase.go
@@ -257,7 +257,7 @@ func getWarningDetails(test TestResult) string {
 	details.WriteString("Warnings:\n")
 	for i, res := range test.Results {
 		for _, warn := range res.Warnings {
-			details.WriteString(fmt.Sprintf("\nStep %d: %s", i+1, warn))
+			fmt.Fprintf(&details, "\nStep %d: %s", i+1, warn)
 		}
 	}
 	return details.String()

--- a/testcase/testcase.go
+++ b/testcase/testcase.go
@@ -28,17 +28,23 @@ const (
 	EnvSourceTestcase EnvSource = "testcase"
 )
 
+type EnvBySource map[EnvSource][]string
+
+func (e EnvBySource) Merge() []string {
+	merged := e[EnvSourceEnviron]
+	merged = append(merged, e[EnvSourceTestcase]...)
+	merged = append(merged, e[EnvSourceCommand]...)
+	merged = append(merged, e[EnvSourceBuiltIn]...)
+	return merged
+}
+
 type testStatus struct {
 	Params TestParameters
-	Env    map[EnvSource][]string
+	Env    EnvBySource
 }
 
 func (t *testStatus) GetEnv() []string {
-	env := t.Env[EnvSourceEnviron]
-	env = append(env, t.Env[EnvSourceTestcase]...)
-	env = append(env, t.Env[EnvSourceCommand]...)
-	env = append(env, t.Env[EnvSourceBuiltIn]...)
-	return env
+	return t.Env.Merge()
 }
 
 func (t *testStatus) GetCelEnv() (*cel.Env, error) {
@@ -81,6 +87,7 @@ type TestParameters struct {
 	TestID           string
 	TestLog          *progress.Progress
 	OutputToTerminal bool
+	WarningsAsErrors bool
 	StdoutWriter     io.Writer
 	StderrWriter     io.Writer
 }
@@ -95,6 +102,15 @@ type TestResult struct {
 	StepsCount   int
 	Results      []StepResult
 	Error        error
+}
+
+func (t TestResult) HasWarnings() bool {
+	for _, res := range t.Results {
+		if len(res.Warnings) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func (t TestResult) SkippedCount() int {
@@ -186,6 +202,14 @@ func removeTestDir(params TestParameters) error {
 
 func getFailureDetails(test TestResult) string {
 	var details strings.Builder
+	if test.HasWarnings() {
+		details.WriteString(getWarningDetails(test))
+
+		if test.FailureCount > 0 {
+			details.WriteString("\n\n")
+		}
+	}
+
 	if test.FailureCount > 0 {
 		details.WriteString("Failures:")
 	} else if test.Error != nil {
@@ -210,6 +234,32 @@ func getFailureDetails(test TestResult) string {
 		fmt.Fprintf(&details, " (%d skipped)", skippedCount)
 	}
 
+	return details.String()
+}
+
+func getSuccessUpdate(path string, test TestResult) messages.Update {
+	status := messages.MessageStatusSuccess
+	details := ""
+	if test.HasWarnings() {
+		status = messages.MessageStatusWarning
+		details = getWarningDetails(test)
+	}
+
+	return messages.Update{Key: path, Status: status, Details: details}
+}
+
+func getWarningDetails(test TestResult) string {
+	if !test.HasWarnings() {
+		return ""
+	}
+
+	var details strings.Builder
+	details.WriteString("Warnings:\n")
+	for i, res := range test.Results {
+		for _, warn := range res.Warnings {
+			details.WriteString(fmt.Sprintf("\nStep %d: %s", i+1, warn))
+		}
+	}
 	return details.String()
 }
 
@@ -282,9 +332,9 @@ func Execute(ctx context.Context, path string, params TestParameters) TestResult
 	}
 
 	test.Finished = time.Now()
-	test.Success = test.FailureCount == 0 && test.Error == nil
+	test.Success = test.FailureCount == 0 && test.Error == nil && (!params.WarningsAsErrors || !test.HasWarnings())
 	if test.Success {
-		_ = testLog.Push(messages.Update{Key: path, Status: messages.MessageStatusSuccess})
+		_ = testLog.Push(getSuccessUpdate(path, test))
 		_ = removeTestDir(params)
 	} else {
 		_ = testLog.Push(messages.Update{Key: path, Status: messages.MessageStatusError, Details: getFailureDetails(test)})

--- a/testcase/teststep.go
+++ b/testcase/teststep.go
@@ -18,9 +18,10 @@ const (
 )
 
 type StepResult struct {
-	Status StepStatus
-	Output string
-	Error  error
+	Status   StepStatus
+	Output   string
+	Error    error
+	Warnings []string
 }
 
 type Step interface {

--- a/testdata/fail_test_environment_variable_values.md
+++ b/testdata/fail_test_environment_variable_values.md
@@ -3,9 +3,12 @@
 ```env
 berry=banana
 fruit=apple
+berry_fruit="${berry}-${fruit}"
 ```
 
 ```sh
 test "$berry" = "strawberry"
 test "$fruit" = "orange"
+test "$berry_fruit" = "strawberry-orange"
+test "$berry_fruit" = "strawberry-orange"
 ```

--- a/testdata/warn_variable_key_whitespace.md
+++ b/testdata/warn_variable_key_whitespace.md
@@ -1,0 +1,5 @@
+# Warn: variable key should not contain whitespace
+
+```env
+  VAR with whitespace=value
+```

--- a/testdata/warn_variable_value_whitespace.md
+++ b/testdata/warn_variable_value_whitespace.md
@@ -1,0 +1,5 @@
+# Warn: variable values that contain whitespace should be quoted
+
+```env
+VAR=Value with whitespace
+```

--- a/testrun/execute.go
+++ b/testrun/execute.go
@@ -41,6 +41,7 @@ func executeTests(ctx context.Context, paths []string, params RunParameters, tes
 					TestID:           id.NewTestID(),
 					TestLog:          testLog,
 					OutputToTerminal: params.OutputToTerminal,
+					WarningsAsErrors: params.WarningsAsErrors,
 				})
 			}(curJobID, curTest)
 		case res := <-returnChan:

--- a/testrun/testrun.go
+++ b/testrun/testrun.go
@@ -24,6 +24,7 @@ type RunParameters struct {
 	OutputTarget     io.Writer
 	Timeout          time.Duration
 	OutputToTerminal bool
+	WarningsAsErrors bool
 }
 
 type RunResult struct {
@@ -126,7 +127,7 @@ func Execute(rawPaths []string, params RunParameters) RunResult {
 				Status:  messages.MessageStatusWarning,
 			}
 		}
-		err := junitReport(run, params.JUnitXML)
+		err := junitReport(run, params)
 		if err != nil {
 			_ = testLog.Push(warning(err))
 		}


### PR DESCRIPTION
- Expand variables in unquoted and double-quoted values in env blocks.
- Warn if variable key or unquoted variable value contains whitespace.
- Warn if unquoted variable value contains inner quotes.
- Add option to treat warnings as errors.
- Include env updates in err stream when using `--output-to-terminal`