### PR TITLE
chore: ignore `goconst` linter in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
       - "go.mod"
       - "go.sum"
       - ".github/workflows/test.yml"
+      - ".golangci.yml"
       - "Makefile"
 
 jobs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,6 +77,8 @@ linters:
               desc: use stdlib instead
     errcheck:
       check-type-assertions: true
+    goconst:
+      ignore-tests: true
     gocritic:
       disabled-checks:
         - commentFormatting


### PR DESCRIPTION
Fixes #107 